### PR TITLE
Fix incompatible declarations

### DIFF
--- a/GDO_Category.php
+++ b/GDO_Category.php
@@ -6,7 +6,7 @@ use GDO\DB\GDT_AutoInc;
 use GDO\DB\GDT_Name;
 /**
  * GDO_Category table inherits Tree.
- * 
+ *
  * @author gizmore
  * @since 2.0
  * @version 5.0
@@ -41,7 +41,8 @@ final class GDO_Category extends GDO_Tree
 		Cache::remove('gdo_category');
 		parent::rebuildFullTree();
 	}
-	public function all()
+
+	public function &all($order=null, $asc=true)
 	{
 		if (false === ($cache = Cache::get('gdo_category')))
 		{

--- a/GDO_Tree.php
+++ b/GDO_Tree.php
@@ -63,7 +63,7 @@ class GDO_Tree extends GDO
 	/**
 	 * @return self[]
 	 */
-	public function all()
+	public function &all($order=null, $asc=true)
 	{
 		return $this->table()->select()->orderASC($this->getLeftColumn())->exec()->fetchAllArray2dObject();
 	}


### PR DESCRIPTION
The overwritten `GDO::all()` implementations need to be compatible to
the parent declaration. (breaks the installer on PHP 8.0)

```
PHP Fatal error:  Declaration of GDO\Category\GDO_Tree::all() must be compatible with & GDO\Core\GDO::all($order = null, $asc = true) in /home/stefan/tmp/gdo6/GDO/Category/GDO_Tree.php on line 66
```